### PR TITLE
Update postgresql-client to 9.6 [THRIVE-3571]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
            libpng-dev \
            libpq-dev \
            openssh-client \
-           postgresql-client \
+           postgresql-client-9.6 \
            zlib1g-dev \
       && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Update the `postgresql-client` in the `thrive-base` dockerfile to match the server version (9.6)